### PR TITLE
bump xedocs, remove rframe dep

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -39,7 +39,6 @@ pymongo==3.13.0
 pytest==7.2.1
 pytest-cov==4.0.0
 pytest-xdist==3.2.0
-rframe==0.2.6
 scikit-learn==1.2.1
 scipy==1.10.0
 tensorflow== 2.11.0
@@ -48,6 +47,6 @@ tqdm==4.64.1
 uproot==4.3.7
 utilix==0.7.2
 xarray==2022.12.0
-xedocs==0.2.16
+xedocs==0.2.20
 zarr==2.14.1
 zstd==1.5.4.0


### PR DESCRIPTION
Bump xedocs to latest version
remove rframe pinned version since its already a managed requirement of xedocs