### PR TITLE
Bump `xedocs` and add dependabot to check `extra_requirements`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: "daily"
     target-branch: "master"
+  - package-ecosystem: "pip"
+    directory: "/extra_requirements"
+    schedule:
+      interval: "daily"
+    target-branch: "master"

--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -47,6 +47,6 @@ tqdm==4.64.1
 uproot==4.3.7
 utilix==0.7.2
 xarray==2022.12.0
-xedocs==0.2.24
+xedocs==0.2.25
 zarr==2.14.1
 zstd==1.5.4.0


### PR DESCRIPTION
1. Bump xedocs to 0.2.25 in `extra_requirements/requirements-tests.txt`
2. Add dependabot to check `extra_requirements/`