### PR TITLE
Drop nestpy requirement

### DIFF
--- a/extra_requirements/requirements-tests.txt
+++ b/extra_requirements/requirements-tests.txt
@@ -24,7 +24,6 @@ memory_profiler==0.61.0
 mongomock==4.1.2
 multihist==0.6.5
 nbmake==1.4.1
-nestpy==2.0.0
 npshmex==0.2.1
 numba==0.58.1
 numexpr==2.8.8


### PR DESCRIPTION
We are able to track `nestpy` again later when https://github.com/NESTCollaboration/nestpy/issues/104 is solved.